### PR TITLE
[Hotfix] Replace semantic tokens with editor decorations for NIP tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,60 +52,36 @@
         "path": "./snippits/snippits.json"
       }
     ],
-    "semanticTokenTypes": [
+    "colors": [
       {
-        "id": "nipProperty",
-        "superType": "property",
-        "description": "NIP property bracket [...]"
+        "id": "nip.property",
+        "description": "Color for NIP property brackets [...] in JS/TS strings",
+        "defaults": { "dark": "#CE9178", "light": "#A31515", "highContrast": "#CE9178", "highContrastLight": "#A31515" }
       },
       {
-        "id": "nipOperator",
-        "superType": "keyword",
-        "description": "NIP operator (==, !=, &&, ||, etc.)"
+        "id": "nip.operator",
+        "description": "Color for NIP operators (==, !=, &&, ||, etc.) in JS/TS strings",
+        "defaults": { "dark": "#C586C0", "light": "#AF00DB", "highContrast": "#C586C0", "highContrastLight": "#AF00DB" }
       },
       {
-        "id": "nipKeyword",
-        "superType": "keyword",
-        "description": "NIP keyword (in / notin)"
+        "id": "nip.keyword",
+        "description": "Color for NIP keywords (in / notin) in JS/TS strings",
+        "defaults": { "dark": "#C586C0", "light": "#AF00DB", "highContrast": "#C586C0", "highContrastLight": "#AF00DB" }
       },
       {
-        "id": "nipNumber",
-        "superType": "number",
-        "description": "NIP numeric value"
+        "id": "nip.number",
+        "description": "Color for NIP numeric values in JS/TS strings",
+        "defaults": { "dark": "#B5CEA8", "light": "#098658", "highContrast": "#B5CEA8", "highContrastLight": "#098658" }
       },
       {
-        "id": "nipSeparator",
-        "superType": "operator",
-        "description": "NIP section separator #"
+        "id": "nip.separator",
+        "description": "Color for NIP section separator (#) in JS/TS strings",
+        "defaults": { "dark": "#D7BA7D", "light": "#800000", "highContrast": "#D7BA7D", "highContrastLight": "#800000" }
       },
       {
-        "id": "nipValue",
-        "superType": "enumMember",
-        "description": "NIP value identifier"
-      }
-    ],
-    "semanticTokenScopes": [
-      {
-        "scopes": {
-          "nipProperty": [
-            "string.regexp"
-          ],
-          "nipOperator": [
-            "keyword.control"
-          ],
-          "nipKeyword": [
-            "keyword.control"
-          ],
-          "nipNumber": [
-            "constant.numeric.nip"
-          ],
-          "nipSeparator": [
-            "constant.character.escape"
-          ],
-          "nipValue": [
-            "keyword.other"
-          ]
-        }
+        "id": "nip.value",
+        "description": "Color for NIP value identifiers in JS/TS strings",
+        "defaults": { "dark": "#9CDCFE", "light": "#0070C1", "highContrast": "#9CDCFE", "highContrastLight": "#0070C1" }
       }
     ]
   },

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -940,7 +940,12 @@ function tokenizeNipContent(content: string): NipToken[] {
 type NipDecorationsMap = Record<NipTokenType, vscode.TextEditorDecorationType>;
 
 function updateNipDecorations(editor: vscode.TextEditor, decorations: NipDecorationsMap) {
-  if (!JS_LANGUAGES.includes(editor.document.languageId)) return;
+  if (!JS_LANGUAGES.includes(editor.document.languageId)) {
+    for (const dt of Object.values(decorations)) {
+      editor.setDecorations(dt, []);
+    }
+    return;
+  }
 
   const nipStrings = findNipStringsInJS(editor.document);
   const rangeMap: Record<NipTokenType, vscode.Range[]> = {

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -937,43 +937,35 @@ function tokenizeNipContent(content: string): NipToken[] {
   return tokens;
 }
 
-// Semantic token types — order must match the legend below
-const NIP_SEMANTIC_TOKEN_TYPES = [
-  "nipProperty",
-  "nipOperator",
-  "nipKeyword",
-  "nipNumber",
-  "nipSeparator",
-  "nipValue",
-] as const;
-const nipTokensLegend = new vscode.SemanticTokensLegend([...NIP_SEMANTIC_TOKEN_TYPES], []);
+type NipDecorationsMap = Record<NipTokenType, vscode.TextEditorDecorationType>;
 
-const NIP_TYPE_INDEX: Record<NipTokenType, number> = {
-  property: 0,
-  operator: 1,
-  keyword: 2,
-  number: 3,
-  separator: 4,
-  value: 5,
-};
+function updateNipDecorations(editor: vscode.TextEditor, decorations: NipDecorationsMap) {
+  if (!JS_LANGUAGES.includes(editor.document.languageId)) return;
 
-const nipSemanticTokensProvider: vscode.DocumentSemanticTokensProvider = {
-  provideDocumentSemanticTokens(document) {
-    if (!JS_LANGUAGES.includes(document.languageId)) return;
-    const builder = new vscode.SemanticTokensBuilder(nipTokensLegend);
-    const nipStrings = findNipStringsInJS(document);
-    for (const match of nipStrings) {
-      for (const token of tokenizeNipContent(match.content)) {
+  const nipStrings = findNipStringsInJS(editor.document);
+  const rangeMap: Record<NipTokenType, vscode.Range[]> = {
+    property: [],
+    operator: [],
+    keyword: [],
+    number: [],
+    separator: [],
+    value: [],
+  };
+
+  for (const match of nipStrings) {
+    for (const token of tokenizeNipContent(match.content)) {
+      const len = token.end - token.start;
+      if (len > 0) {
         const col = match.startColumn + token.start;
-        const len = token.end - token.start;
-        if (len > 0) {
-          builder.push(match.lineNumber, col, len, NIP_TYPE_INDEX[token.type], 0);
-        }
+        rangeMap[token.type].push(new vscode.Range(match.lineNumber, col, match.lineNumber, col + len));
       }
     }
-    return builder.build();
-  },
-};
+  }
+
+  for (const [type, ranges] of Object.entries(rangeMap) as [NipTokenType, vscode.Range[]][]) {
+    editor.setDecorations(decorations[type], ranges);
+  }
+}
 
 export function activate(context: vscode.ExtensionContext) {
   const diagnosticCollection = vscode.languages.createDiagnosticCollection("vsnip-check");
@@ -993,12 +985,26 @@ export function activate(context: vscode.ExtensionContext) {
   //     }
   //   )
   // );
+  const nipDecorations: NipDecorationsMap = {
+    property: vscode.window.createTextEditorDecorationType({ color: new vscode.ThemeColor("nip.property") }),
+    operator: vscode.window.createTextEditorDecorationType({ color: new vscode.ThemeColor("nip.operator") }),
+    keyword: vscode.window.createTextEditorDecorationType({ color: new vscode.ThemeColor("nip.keyword") }),
+    number: vscode.window.createTextEditorDecorationType({ color: new vscode.ThemeColor("nip.number") }),
+    separator: vscode.window.createTextEditorDecorationType({ color: new vscode.ThemeColor("nip.separator") }),
+    value: vscode.window.createTextEditorDecorationType({ color: new vscode.ThemeColor("nip.value") }),
+  };
+  for (const dt of Object.values(nipDecorations)) context.subscriptions.push(dt);
+
+  // Seed decorations for any editors already open when the extension activates.
+  for (const editor of vscode.window.visibleTextEditors) updateNipDecorations(editor, nipDecorations);
+
   context.subscriptions.push(
-    vscode.languages.registerDocumentSemanticTokensProvider(
-      JS_LANGUAGES.map((lang) => ({ language: lang })),
-      nipSemanticTokensProvider,
-      nipTokensLegend,
-    ),
+    vscode.window.onDidChangeActiveTextEditor((editor) => {
+      if (editor) updateNipDecorations(editor, nipDecorations);
+    }),
+    vscode.window.onDidChangeVisibleTextEditors((editors) => {
+      for (const editor of editors) updateNipDecorations(editor, nipDecorations);
+    }),
   );
 
   context.subscriptions.push(
@@ -1013,6 +1019,9 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.workspace.onDidChangeTextDocument((event) => {
       validateTextDocument(event.document, diagnosticCollection);
       validateJSNipStrings(event.document, diagnosticCollection);
+      for (const editor of vscode.window.visibleTextEditors) {
+        if (editor.document === event.document) updateNipDecorations(editor, nipDecorations);
+      }
     }),
     vscode.workspace.onDidCloseTextDocument((document) => {
       diagnosticCollection.delete(document.uri);


### PR DESCRIPTION
This pull request refactors how NIP syntax highlighting is implemented in the extension. Instead of using semantic tokens, it now uses editor decorations with theme-aware colors for NIP elements in JavaScript and TypeScript strings. This change improves compatibility and gives more direct control over the appearance of NIP syntax highlighting.

Key changes:

**Theme-aware NIP syntax highlighting:**
- Replaces the previous semantic token types and legend with a new `colors` section in `package.json`, defining theme-aware colors for each NIP syntax element (property, operator, keyword, number, separator, value).
- Removes the semantic tokens provider and instead applies highlighting using `TextEditorDecorationType` objects, mapping each NIP token type to its corresponding color. [[1]](diffhunk://#diff-da8cc70370d67b4c482d5cf755fb7f45697844107dd73ccf7f5b54162703f63cL940-R968) [[2]](diffhunk://#diff-da8cc70370d67b4c482d5cf755fb7f45697844107dd73ccf7f5b54162703f63cR988-R1007)

**Decoration management and updates:**
- Adds logic to update decorations for all open editors on activation and whenever editors are opened, become visible, or when their content changes. This ensures NIP syntax is always highlighted correctly as users interact with files. [[1]](diffhunk://#diff-da8cc70370d67b4c482d5cf755fb7f45697844107dd73ccf7f5b54162703f63cR988-R1007) [[2]](diffhunk://#diff-da8cc70370d67b4c482d5cf755fb7f45697844107dd73ccf7f5b54162703f63cR1022-R1024)