### PR TITLE
[Patch] Error on standalone commas

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -599,9 +599,7 @@ function validateTextDocument(textDocument: vscode.TextDocument, diagnosticColle
       while ((cm = commaPat.exec(lines[i])) !== null) {
         const pos = cm.index;
         if (!validRanges.some(([s, e]) => pos >= s && pos < e)) {
-          diagnostics.push(
-            new vscode.Diagnostic(new vscode.Range(i, pos, i, pos + 1), "Unexpected comma"),
-          );
+          diagnostics.push(new vscode.Diagnostic(new vscode.Range(i, pos, i, pos + 1), "Unexpected comma"));
         }
       }
     }

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -331,12 +331,14 @@ function validateNipString(nipLine: string, originalLine: string): NipDiagnostic
     const validRanges: [number, number][] = [];
     const inPat = /\b(?:in|notin)\s*\([^)]*\)/gi;
     let inm: RegExpExecArray | null;
-    while ((inm = inPat.exec(originalLine)) !== null) {
+    const commentIndex = originalLine.indexOf("//");
+    const lineWithoutComment = commentIndex === -1 ? originalLine : originalLine.slice(0, commentIndex);
+    while ((inm = inPat.exec(lineWithoutComment)) !== null) {
       validRanges.push([inm.index, inm.index + inm[0].length]);
     }
     const commaPat = /,/g;
     let cm: RegExpExecArray | null;
-    while ((cm = commaPat.exec(originalLine)) !== null) {
+    while ((cm = commaPat.exec(lineWithoutComment)) !== null) {
       const pos = cm.index;
       if (!validRanges.some(([s, e]) => pos >= s && pos < e)) {
         results.push({ message: "Unexpected comma", startOffset: pos, endOffset: pos + 1 });

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -326,6 +326,24 @@ function validateNipString(nipLine: string, originalLine: string): NipDiagnostic
 
   if (line.length < 5) return results;
 
+  // Flag commas that are not inside an in/notin list, e.g. "shield, 2" is invalid.
+  {
+    const validRanges: [number, number][] = [];
+    const inPat = /\b(?:in|notin)\s*\([^)]*\)/gi;
+    let inm: RegExpExecArray | null;
+    while ((inm = inPat.exec(originalLine)) !== null) {
+      validRanges.push([inm.index, inm.index + inm[0].length]);
+    }
+    const commaPat = /,/g;
+    let cm: RegExpExecArray | null;
+    while ((cm = commaPat.exec(originalLine)) !== null) {
+      const pos = cm.index;
+      if (!validRanges.some(([s, e]) => pos >= s && pos < e)) {
+        results.push({ message: "Unexpected comma", startOffset: pos, endOffset: pos + 1 });
+      }
+    }
+  }
+
   const sections = line.split("#");
 
   for (let j = 0; j < sections.length; j++) {
@@ -567,6 +585,27 @@ function validateTextDocument(textDocument: vscode.TextDocument, diagnosticColle
 
     const line = lines[i].replace(/\s+/g, "").toLowerCase();
     if (line.length < 5) continue;
+
+    // Flag commas that are not inside an in/notin list.
+    {
+      const validRanges: [number, number][] = [];
+      const inPat = /\b(?:in|notin)\s*\([^)]*\)/gi;
+      let inm: RegExpExecArray | null;
+      while ((inm = inPat.exec(lines[i])) !== null) {
+        validRanges.push([inm.index, inm.index + inm[0].length]);
+      }
+      const commaPat = /,/g;
+      let cm: RegExpExecArray | null;
+      while ((cm = commaPat.exec(lines[i])) !== null) {
+        const pos = cm.index;
+        if (!validRanges.some(([s, e]) => pos >= s && pos < e)) {
+          diagnostics.push(
+            new vscode.Diagnostic(new vscode.Range(i, pos, i, pos + 1), "Unexpected comma"),
+          );
+        }
+      }
+    }
+
     const sections = line.split("#");
 
     for (let j = 0; j < sections.length; j++) {


### PR DESCRIPTION
This pull request adds a new validation to flag commas that are not inside an `in` or `notin` list, helping to catch invalid comma usage in NIP lines and documents. The logic is implemented both in the per-line validation and in the overall document validation.

Validation improvements:

* Added logic in `validateNipString` to detect and report commas that are not inside an `in` or `notin` list, marking them as "Unexpected comma" errors.
* Added similar logic in `validateTextDocument` to flag commas outside of `in`/`notin` lists at the document level, generating diagnostics for each occurrence.