### PR TITLE
[Patch] Fix using JSDOC NipString annotation

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -150,8 +150,12 @@ function findNipStringsInJS(document: vscode.TextDocument): NipStringMatch[] {
 
     // Track block depth and extract strings when inside a NIP block
     if (inNipBlock) {
+      // Strip JSDoc comments before counting brackets/braces so that the `[]` inside
+      // `/** @type {NipString[]} */` on a standalone line isn't counted as array depth.
+      const lineForDepth = line.replace(/\/\*\*.*?\*\//g, "");
+
       // Count opening and closing brackets/braces
-      for (const ch of line) {
+      for (const ch of lineForDepth) {
         if (blockType === "array" && ch === "[") blockDepth++;
         if (blockType === "array" && ch === "]") blockDepth--;
         if (blockType === "object" && ch === "{") blockDepth++;
@@ -180,7 +184,7 @@ function findNipStringsInJS(document: vscode.TextDocument): NipStringMatch[] {
       }
 
       // Check if block has ended
-      if (blockDepth <= 0 && (line.includes("]") || line.includes("}"))) {
+      if (blockDepth <= 0 && (lineForDepth.includes("]") || lineForDepth.includes("}"))) {
         inNipBlock = false;
         blockType = null;
       }


### PR DESCRIPTION
This pull request improves the logic for detecting the end of NIP blocks in JavaScript by ensuring that JSDoc comments do not interfere with bracket or brace counting. This prevents issues where brackets inside comments could cause the parser to incorrectly calculate block depth.

**Block parsing improvements:**

* Stripped JSDoc comments from each line before counting brackets and braces to avoid miscounting array or object depth due to comment content.
* Updated the condition for detecting the end of a block to use the comment-stripped line, ensuring more accurate block closure detection.